### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/SonarCloud.yml
+++ b/.github/workflows/SonarCloud.yml
@@ -1,4 +1,6 @@
 name: SonarCloud
+permissions:
+  contents: read
 on:
   push:
     branches:

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -1,4 +1,6 @@
 name: Django CI
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,4 +1,6 @@
 name: Pylint
+permissions:
+  contents: read
 
 on: [push]
 


### PR DESCRIPTION
Potential fix for [https://github.com/pep-un/Oxomium/security/code-scanning/5](https://github.com/pep-un/Oxomium/security/code-scanning/5)

To fix the problem, add a `permissions` block to the workflow. The best practice is to set this at the top level of the workflow file, so it applies to all jobs unless overridden. The minimal required permission for most workflows is `contents: read`. If the SonarCloud action needs to comment on pull requests, you may also need `pull-requests: write`, but the minimal starting point is `contents: read`. This change should be made at the top of the `.github/workflows/SonarCloud.yml` file, immediately after the `name:` line and before the `on:` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
